### PR TITLE
Fix syntax error when title contains `'`

### DIFF
--- a/docs/src/app.rb
+++ b/docs/src/app.rb
@@ -7,6 +7,9 @@ end
 
 # HTML encode helper
 def html(value)
+  # FIXME: Workaround for syntax error
+  value = value.gsub("'", "\\\\'")
+
   CGI.escapeHTML(value)
 end
 


### PR DESCRIPTION
I think syntax error is occured at following
https://github.com/getty104/ruby-wasm-vdom/blob/610ae77983d6c2eb18fca7feddc8b2e2038d9f58/docs/index.js#L211

Close #8