### PR TITLE
Migrate to @ruby/head-wasm-wasi

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,15 @@
   </footer>
 </div>
 
-<script src="https://getty104.github.io/ruby-wasm-vdom/index.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@ruby/head-wasm-wasi/dist/browser.script.iife.min.js"></script>
+
+<script type="text/ruby" src="https://getty104.github.io/ruby-wasm-vdom/ruby_wasm_vdom.rb"></script>
+<script type="text/ruby" src="https://getty104.github.io/ruby-wasm-vdom/ruby_wasm_vdom/init.rb"></script>
+<script type="text/ruby" src="https://getty104.github.io/ruby-wasm-vdom/ruby_wasm_vdom/dom_parser.rb"></script>
+<script type="text/ruby" src="https://getty104.github.io/ruby-wasm-vdom/ruby_wasm_vdom/dom_manager.rb"></script>
+<script type="text/ruby" src="https://getty104.github.io/ruby-wasm-vdom/ruby_wasm_vdom/app.rb"></script>
+<script type="text/ruby" src="https://getty104.github.io/ruby-wasm-vdom/ruby_wasm_vdom/router.rb"></script>
+
 <script src="./src/app.rb?20240201" type="text/ruby"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
 </body>


### PR DESCRIPTION
https://github.com/getty104/ruby-wasm-vdom uses https://www.jsdelivr.com/package/npm/ruby-head-wasm-wasi

ref. https://github.com/getty104/ruby-wasm-vdom/blob/f647e7766db569248718466fb425ffe9d8acafb3/docs/index.js#L4

But current ruby-head-wasm-wasi is https://www.jsdelivr.com/package/npm/@ruby/head-wasm-wasi